### PR TITLE
`scrapy genspider` creates `import DirbotItem` but I get ImportError: cannot import name DirbotItem

### DIFF
--- a/dirbot/items.py
+++ b/dirbot/items.py
@@ -1,10 +1,15 @@
 from scrapy.item import Item, Field
 
-class Website(Item):
+
+class DirbotItem(Item):
 
     name = Field()
-    url = Field()
     description = Field()
 
+
+class Website(DirbotItem):
+
+    url = Field()
+
     def __str__(self):
-        return "Website: name=%s url=%s" % (self['name'], self['url'])
+        return "Website: name=%s url=%s" % (self.get('name'), self.get('url'))

--- a/dirbot/pipelines.py
+++ b/dirbot/pipelines.py
@@ -1,5 +1,6 @@
 from scrapy.exceptions import DropItem
 
+
 class FilterWordsPipeline(object):
     """A pipeline for filtering out items which contain certain words in their
     description"""

--- a/dirbot/settings.py
+++ b/dirbot/settings.py
@@ -9,4 +9,3 @@ DEFAULT_ITEM_CLASS = 'dirbot.items.Website'
 USER_AGENT = '%s/%s' % (BOT_NAME, BOT_VERSION)
 
 ITEM_PIPELINES = ['dirbot.pipelines.FilterWordsPipeline']
-

--- a/dirbot/spiders/dmoz.py
+++ b/dirbot/spiders/dmoz.py
@@ -3,22 +3,25 @@ from scrapy.selector import HtmlXPathSelector
 
 from dirbot.items import Website
 
-class DmozSpider(BaseSpider):
-   name = "dmoz"
-   allowed_domains = ["dmoz.org"]
-   start_urls = [
-       "http://www.dmoz.org/Computers/Programming/Languages/Python/Books/",
-       "http://www.dmoz.org/Computers/Programming/Languages/Python/Resources/"
-   ]
 
-   def parse(self, response):
-       hxs = HtmlXPathSelector(response)
-       sites = hxs.select('//ul/li')
-       items = []
-       for site in sites:
-           item = Website()
-           item['name'] = site.select('a/text()').extract()
-           item['url'] = site.select('a/@href').extract()
-           item['description'] = site.select('text()').extract()
-           items.append(item)
-       return items
+class DmozSpider(BaseSpider):
+    name = "dmoz"
+    allowed_domains = ["dmoz.org"]
+    start_urls = [
+        "http://www.dmoz.org/Computers/Programming/Languages/Python/Books/",
+        "http://www.dmoz.org/Computers/Programming/Languages/Python/Resources/",
+    ]
+
+    def parse(self, response):
+        hxs = HtmlXPathSelector(response)
+        sites = hxs.select('//ul/li')
+        items = []
+
+        for site in sites:
+            item = Website()
+            item['name'] = site.select('a/text()').extract()
+            item['url'] = site.select('a/@href').extract()
+            item['description'] = site.select('text()').extract()
+            items.append(item)
+
+        return items


### PR DESCRIPTION
After running:

```
stav@maia:/srv/scrapy/dirbot-fork$ scrapy genspider test example.com
Created spider 'test' using template 'crawl' in module:
  dirbot.spiders.test
```

I get an error trying to compile the spider:

```
stav@maia:/srv/scrapy/dirbot$ scrapy shell
2012-06-07 18:06:12-0500 [scrapy] INFO: Scrapy 0.15.1 started (bot: dirbot)
2012-06-07 18:06:12-0500 [scrapy] DEBUG: Enabled extensions: TelnetConsole, CloseSpider, WebService, CoreStats, SpiderState
Traceback (most recent call last):
  File "/usr/local/bin/scrapy", line 5, in <module>
    pkg_resources.run_script('Scrapy==0.15.1', 'scrapy')
  File "/usr/local/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg/pkg_resources.py", line 489, in run_script
  File "/usr/local/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg/pkg_resources.py", line 1207, in run_script
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/EGG-INFO/scripts/scrapy", line 4, in <module>
    execute()
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/cmdline.py", line 110, in execute
    _run_print_help(parser, _run_command, cmd, args, opts)
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/cmdline.py", line 76, in _run_print_help
    func(*a, **kw)
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/cmdline.py", line 117, in _run_command
    cmd.run(args, opts)
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/commands/shell.py", line 38, in run
    shell = Shell(self.crawler, update_vars=self.update_vars, inthread=True, \
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/command.py", line 32, in crawler
    self._crawler.configure()
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/crawler.py", line 36, in configure
    self.spiders = spman_cls.from_crawler(self)
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/spidermanager.py", line 37, in from_crawler
    return cls.from_settings(crawler.settings)
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/spidermanager.py", line 33, in from_settings
    return cls(settings.getlist('SPIDER_MODULES'))
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/spidermanager.py", line 23, in __init__
    for module in walk_modules(name):
  File "/usr/local/lib/python2.6/site-packages/Scrapy-0.15.1-py2.6.egg/scrapy/utils/misc.py", line 65, in walk_modules
    submod = __import__(fullpath, {}, {}, [''])
  File "/srv/scrapy/dirbot/dirbot/spiders/test.py", line 4, in <module>
    from dirbot.items import DirbotItem
ImportError: cannot import name DirbotItem
```

So I added DirbotItem to items.py and PEP'd up a couple other files as well.
