### PR TITLE
Added a class on selector

### DIFF
--- a/dirbot/spiders/dmoz.py
+++ b/dirbot/spiders/dmoz.py
@@ -21,7 +21,7 @@ class DmozSpider(BaseSpider):
         @scrapes name
         """
         hxs = HtmlXPathSelector(response)
-        sites = hxs.select('//ul/li')
+        sites = hxs.select('//ul[@class="directory-url"]/li')
         items = []
 
         for site in sites:


### PR DESCRIPTION
Added a class on the selector so that only expected elements show up in result.

Considering page http://www.dmoz.org/Computers/Programming/Languages/Python/Books/.
We expect "An Introduction to Python" to be the first entry in our result, as per the requirement stated at [scrapy tutorial](http://doc.scrapy.org/en/latest/intro/tutorial.html#intro-tutorial). However the first entry we were getting is "Website: name=[u'Top'] url=[u'/']" which should not be the case.
So, this fix.
