### PR TITLE
Corrected link to tutorial

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ default (defined in the ``start_pages`` attribute). These pages are:
 So, if you run the spider regularly (with ``scrapy crawl dmoz``) it will scrape
 only those two pages.
 
-.. _Scrapy tutorial: http://doc.scrapy.org/intro/tutorial.html 
+.. _Scrapy tutorial: http://doc.scrapy.org/en/latest/intro/tutorial.html
 
 Pipelines
 =========


### PR DESCRIPTION
Cool example. The link to the tutorial docs was not up to date and directed to a "site not found" page. Corrected link in this PR.
