### PR TITLE
DMOZ Site Update

### DIFF
--- a/dirbot/items.py
+++ b/dirbot/items.py
@@ -3,6 +3,6 @@ from scrapy.item import Item, Field
 
 class Website(Item):
 
-    name = Field()
-    description = Field()
-    url = Field()
+    title = Field()
+    link = Field()
+    desc = Field()

--- a/dirbot/pipelines.py
+++ b/dirbot/pipelines.py
@@ -10,7 +10,7 @@ class FilterWordsPipeline(object):
 
     def process_item(self, item, spider):
         for word in self.words_to_filter:
-            if word in unicode(item['description']).lower():
+            if word in unicode(item['desc']).lower():
                 raise DropItem("Contains forbidden word: %s" % word)
         else:
             return item

--- a/dirbot/spiders/dmoz.py
+++ b/dirbot/spiders/dmoz.py
@@ -1,3 +1,5 @@
+import scrapy
+
 from scrapy.spiders import Spider
 from scrapy.selector import Selector
 
@@ -21,14 +23,14 @@ class DmozSpider(Spider):
         @scrapes name
         """
         sel = Selector(response)
-        sites = sel.xpath('//ul[@class="directory-url"]/li')
+        sites = sel.xpath('//div[@class="title-and-desc"]')
         items = []
 
         for site in sites:
             item = Website()
-            item['name'] = site.xpath('a/text()').extract()
-            item['url'] = site.xpath('a/@href').extract()
-            item['description'] = site.xpath('text()').re('-\s[^\n]*\\r')
+            item['title'] = site.xpath('a/text()').extract()
+            item['link'] = site.xpath('a/@href').extract()
+            item['desc'] = site.xpath('//div[@class="site-descr "]/text()').re('-\s[^\n]*\\r')
             items.append(item)
 
         return items


### PR DESCRIPTION
The DMOZ site updated it’s format, breaking the tutorial. This restores
the tutorial, and attempts to keep the //ul/li filtering scheme. Class
items were renamed to match the tutorial.